### PR TITLE
Feat: More languages for auto-translate & Added https://lingva.garudalinux.org/ as another fallback

### DIFF
--- a/app/src/main/java/com/nyantv/ui/player/LingvaTranslator.kt
+++ b/app/src/main/java/com/nyantv/ui/player/LingvaTranslator.kt
@@ -11,7 +11,7 @@ import java.net.URLEncoder
  * Lightweight Lingva Translate client.
  *
  * Lingva is an open-source front-end for Google Translate with no API key required.
- * Public instances: https://lingva.ml  (default)
+ * Tries each instance in order, falling back to the next if one fails.
  *
  * API: GET /api/v1/{source}/{target}/{encoded_text}
  * Response: { "translation": "..." }
@@ -20,7 +20,10 @@ import java.net.URLEncoder
  * (e.g. OP/ED lyrics that repeat) don't make duplicate requests.
  */
 class LingvaTranslator(
-    private val baseUrl: String = "https://lingva.ml",
+    private val baseUrls: List<String> = listOf(
+        "https://lingva.garudalinux.org",
+        "https://lingva.ml"
+    ),
     private val sourceLang: String = "auto",
     val targetLang: String
 ) {
@@ -30,14 +33,19 @@ class LingvaTranslator(
     suspend fun translate(text: String): String {
         if (text.isBlank()) return text
         cache.get(text)?.let { return it }
-
         return withContext(Dispatchers.IO) {
-            runCatching {
-                val encoded  = URLEncoder.encode(text, "UTF-8")
-                val endpoint = "$baseUrl/api/v1/$sourceLang/$targetLang/$encoded"
-                val json     = URL(endpoint).readText(Charsets.UTF_8)
-                JSONObject(json).getString("translation")
-            }.getOrDefault(text) // on failure, return original
+            val encoded = URLEncoder.encode(text, "UTF-8")
+            var result = text
+            for (base in baseUrls) {
+                result = runCatching {
+                    val json = URL("$base/api/v1/$sourceLang/$targetLang/$encoded").readText(Charsets.UTF_8)
+                    val obj = JSONObject(json)
+                    if (obj.has("error")) error("Instance failed: $base")
+                    obj.getString("translation")
+                }.getOrNull() ?: continue
+                break
+            }
+            result
         }.also { result ->
             cache.put(text, result)
         }

--- a/app/src/main/java/com/nyantv/ui/settings/sub_settings/PlayerSettingsScreen.kt
+++ b/app/src/main/java/com/nyantv/ui/settings/sub_settings/PlayerSettingsScreen.kt
@@ -309,7 +309,7 @@ fun PlayerSettingsScreen(navController: NavController) {
 
             // Auto-translate dropdown
             var translateExpanded by remember { mutableStateOf(false) }
-            val translateOptions = listOf(null, "en", "de", "fr", "es", "ja", "ko", "zh")
+            val translateOptions = listOfval translateOptions = listOf(null, "en", "de", "fr", "es", "ja", "ko", "zh", "as", "bn", "brx", "doi", "gu", "hi", "kn", "ks", "gom", "mai", "ml", "mni-Mtei", "mr", "ne", "or", "pa", "sa", "sat", "sd", "ta", "te", "ur", "it", "pt", "ru", "pl", "nl", "uk", "sv", "ht", "qu", "vi", "th", "id", "ms", "tl", "my", "km", "ar", "fa", "tr", "uz", "kk", "az", "sw", "am", "yo", "ig", "ha", "zu", "so", "mg")
 
             Row(
                 modifier = Modifier


### PR DESCRIPTION
All languages that can be selected for the auto-translation are:
English, German, French, Spanish, Japanese, Korean, Chinese, Assamese, Bengali, Bodo, Dogri, Gujarati, Hindi, Kannada, Kashmiri, Konkani, Maithili, Malayalam, Manipuri, Marathi, Nepali, Odia, Punjabi, Sanskrit, Santhali, Sindhi, Tamil, Telugu, Urdu, Italian, Portuguese, Russian, Polish, Dutch, Ukrainian, Swedish, Haitian Creole, Quechua, Vietnamese, Thai, Indonesian, Malay, Filipino/Tagalog, Burmese, Khmer, Arabic, Persian/Farsi, Turkish, Uzbek, Kazakh, Azerbaijani, Swahili, Amharic, Yoruba, Igbo, Hausa, Zulu, Somali, Malagasy

Total: 60 options (including "Off")